### PR TITLE
Fix matplotlib dependency on conda-recipe as well

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
   {{ hash_type }} : {{ hash_value }}
 
 build:
-  number: 0
+  number: 1
   script:
     - {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
 
@@ -27,7 +27,7 @@ requirements:
     - cython
     - python
     - matplotlib >=2.2,<3.0  # [py2k]
-    - matplotlib >=2.2       # [not py2k]
+    - matplotlib >=2.2,<3.1  # [not py2k]
     - networkx
     - numba
     - numpy >=1.15


### PR DESCRIPTION
This is already fixed on the `requirements.txt` file but needs to be reflected here as well.

Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
